### PR TITLE
Dev/1.0.1

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -27,12 +27,12 @@ usbinfo module
 
    .. autofunction:: usbinfo
 
-Invocation of ``usbtool`` command line tool
+Invocation of ``usbinfo`` command line tool
 ===========================================
 
-The :program:`usbtool` allows for gathering of information of endpoints on
+The :program:`usbinfo` allows for gathering of information of endpoints on
 the USB subsystem from the command line. When invoked without any arguments,
-:program:`usbtool` prints a tabular representation of attached USB endpoints:
+:program:`usbinfo` prints a tabular representation of attached USB endpoints:
 
 .. code-block:: none
 
@@ -57,9 +57,9 @@ the USB subsystem from the command line. When invoked without any arguments,
      0930:6545 Kingston     DataTraveler 2.0                   AC221C280D9FFEABC85A1812
      0930:6545 Kingston     DataTraveler 2.0                   AC221C280D9FFEABC85A1812 0   /dev/disk2s1 => /Volumes/KINGSTON
 
-The :program:`usbtool` script has several options:
+The :program:`usbinfo` script has several options:
 
-.. program:: usbtool
+.. program:: usbinfo
 
 .. option:: --csv
 
@@ -84,7 +84,7 @@ Version 1.0
 
 * Added :mod:`.usbinfo` allowing scripts to obtain information from USB
   subsystem.
-* Added ``usbtool`` script to allow command line usage of :mod:`.usbinfo`
+* Added ``usbinfo`` script to allow command line usage of :mod:`.usbinfo`
 * Added documentation
 
 Pexpect is developed on `Github <https://github.com/google/usbinfo>`_.

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from setuptools import setup
 PKG_NAME = 'usbinfo'
 PKG_VERSION_MAJOR = 1
 PKG_VERSION_MINOR = 0
-PKG_VERSION_MICRO = 0
+PKG_VERSION_MICRO = 1
 PKG_VERSION = '{major}.{minor}.{micro}'.format(
     major=PKG_VERSION_MAJOR,
     minor=PKG_VERSION_MINOR,

--- a/usbinfo/__main__.py
+++ b/usbinfo/__main__.py
@@ -149,6 +149,7 @@ def _parse_options(args):
         Set default values for arguments not available on certain platform.
         """
         def __init__(self):
+            self.csv = False
             self.endpoints = False
             self.endpoint_total = False
 

--- a/usbinfo/linux.py
+++ b/usbinfo/linux.py
@@ -33,7 +33,18 @@ def usbinfo():
     context = pyudev.Context()
     devices = context.list_devices().match_property('ID_BUS', 'usb')
 
-    for device in devices:
+    device_it = devices.__iter__()
+
+    while 1:
+        try:
+            # We need to manually get the next item in the iterator because
+            # pyudev.device may throw an exception
+            device = device_it.next()
+        except pyudev.device.DeviceNotFoundError:
+            continue
+        except StopIteration:
+            break
+
         devinfo = {
             'bInterfaceNumber': device.get('ID_USB_INTERFACE_NUM', u''),
             'iManufacturer': device.get('ID_VENDOR', u''),
@@ -41,7 +52,7 @@ def usbinfo():
             'iProduct': device.get('ID_MODEL', u''),
             'idProduct': device.get('ID_MODEL_ID', u''),
             'iSerialNumber': device.get('ID_SERIAL_SHORT', u''),
-            'devname': device.get('DEVNAME', ''),
+            'devname': device.get('DEVNAME', u''),
         }
 
         mount = _mounts.get(device.get('DEVNAME'))


### PR DESCRIPTION
- Fix documentation to show `usbinfo` instead of `usbtool`
- Handle rare corner case in Linux where USB device is unplugged and causes exception
- Fix to include devname when running El Capitan
