### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ useful in robotics and device automation and allows developers to write
 more portable code.
 
 More information can be found in the
-[documentation](http://usbinfo.readthedocs.org/en/latest/).
+[documentation](https://usbinfo.readthedocs.io/en/latest/).


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
