### PR TITLE
Fix Python 3.6.0

### DIFF
--- a/usbinfo/darwin.py
+++ b/usbinfo/darwin.py
@@ -101,7 +101,7 @@ def _extra_if_info(node):
     info = {}
 
     for child in node.get('IORegistryEntryChildren', []):
-        for class_name, handler in ioclass_handlers.items():
+        for class_name, handler in iter(ioclass_handlers.items()):
             if child.get('IOObjectClass') == class_name:
                 info.update(handler(child))
         info.update(_extra_if_info(child))

--- a/usbinfo/darwin.py
+++ b/usbinfo/darwin.py
@@ -38,9 +38,13 @@ def _ioreg_usb_devices(nodename=None):
         """Run ioreg command on specific node name"""
         cmd = ['ioreg', '-a', '-l', '-r', '-n', nodename]
         output = subprocess.check_output(cmd)
+        plist_data = []
         if output:
-            return plistlib.readPlistFromString(output)
-        return []
+            try:
+                plist_data = plistlib.readPlistFromString(output)
+            except AttributeError as e:
+                plist_data = plistlib.loads(output)
+        return plist_data
 
     if nodename is None:
         xhci = _ioreg('AppleUSBXHCI')
@@ -97,7 +101,7 @@ def _extra_if_info(node):
     info = {}
 
     for child in node.get('IORegistryEntryChildren', []):
-        for class_name, handler in ioclass_handlers.iteritems():
+        for class_name, handler in ioclass_handlers.items():
             if child.get('IOObjectClass') == class_name:
                 info.update(handler(child))
         info.update(_extra_if_info(child))


### PR DESCRIPTION
Python 3.6.0's plistlib has removed readPlistFromString in favor of loads.  There isn't a backwards compatible upgrade path, so feature detection was necessary instead.

This patch fixes Python 3.6.0 by trying plistlib.loads when AttributeError is thrown from attempting to call plistlib.readPlistFromString.

Additionally, dict.iteritems() is deprecated in favor of dict.items() in Python 3.  This also works in Python 2.7.

Tested both Python 2.7 (standard install) and Python 3.6.0 (Anaconda) on macOS Sierra 10.12.4 (16E195).