### PR TITLE
Fix Python 3.6.0

### DIFF
--- a/usbinfo/darwin.py
+++ b/usbinfo/darwin.py
@@ -101,7 +101,7 @@ def _extra_if_info(node):
     info = {}
 
     for child in node.get('IORegistryEntryChildren', []):
-        for class_name, handler in ioclass_handlers.items():
+        for class_name, handler in iter(ioclass_handlers.items()):
             if child.get('IOObjectClass') == class_name:
                 info.update(handler(child))
         info.update(_extra_if_info(child))

--- a/usbinfo/darwin.py
+++ b/usbinfo/darwin.py
@@ -30,14 +30,23 @@ OSX_VERSION_MAJOR_INT, \
 OSX_VERSION_MINOR_INT, \
 OSX_VERSION_MICRO_INT = [int(part) for part in OSX_VERSION_STR.split('.')]
 
+sanitize_pattern = re.compile(r'^(\s*?\<string\>)(.*?)(\<\/string\>.*?)$')
 
 def _sanitize_xml(data):
-    pattern = re.compile(r'^(\s*?\<string\>)(.*?)(\<\/string\>.*?)$')
+    """Takes an plist (xml) and checks <string> defintions for control characters.
+
+       If a control character is found, the string is converted to hexidecimal.
+       For ST-Link devices, this properly displays the serial number, which 
+       is eroneously encoded as binary data, which causes the plistlib XML parser
+       to crash.
+
+       Returns the same document, with any mis-encoded <string> values converted 
+       to ascii hex."""
     output = []
 
     for i, line in enumerate(data.split('\n')):
         chunk = line.decode('utf-8')
-        match = re.match(pattern, chunk)
+        match = re.match(sanitize_pattern, chunk)
         if match:
             start = match.group(1)
             middle = match.group(2)

--- a/usbinfo/darwin.py
+++ b/usbinfo/darwin.py
@@ -53,15 +53,16 @@ def _sanitize_xml(data):
                 new_line = '{start}{middle}{end}'.format(start=start,
                                                          middle=middle,
                                                          end=end)
-                output.append(new_line)
+                output.append(new_line.encode('utf-8'))
             else:
+                # Already encoded.
                 output.append(line)
         else:
+            # Already encoded
             output.append(line)
     output = '\n'.join(output)
 
-    return output.encode('utf-8')
-
+    return output
 
 def _ioreg_usb_devices(nodename=None):
     """Returns a list of USB device tree from ioreg"""

--- a/usbinfo/darwin.py
+++ b/usbinfo/darwin.py
@@ -44,8 +44,10 @@ def _sanitize_xml(data):
        to ascii hex."""
     output = []
 
+    data = data.decode('utf-8')
+
     for i, line in enumerate(data.split('\n')):
-        chunk = line.decode('utf-8')
+        chunk = line
         match = re.match(sanitize_pattern, chunk)
         if match:
             start = match.group(1)
@@ -62,16 +64,14 @@ def _sanitize_xml(data):
                 new_line = '{start}{middle}{end}'.format(start=start,
                                                          middle=middle,
                                                          end=end)
-                output.append(new_line.encode('utf-8'))
+                output.append(new_line)
             else:
-                # Already encoded.
                 output.append(line)
         else:
-            # Already encoded
             output.append(line)
-    output = '\n'.join(output)
+    output = '\n'.join([line for line in output])
 
-    return output
+    return output.encode('utf-8')
 
 def _ioreg_usb_devices(nodename=None):
     """Returns a list of USB device tree from ioreg"""

--- a/usbinfo/darwin.py
+++ b/usbinfo/darwin.py
@@ -26,9 +26,14 @@ from .posix import get_mounts
 # platform.mac_ver()'s first tuple element encodes the OS X version,
 # such as 10.11.3.
 OSX_VERSION_STR = platform.mac_ver()[0]
-OSX_VERSION_MAJOR_INT, \
-OSX_VERSION_MINOR_INT, \
-OSX_VERSION_MICRO_INT = [int(part) for part in OSX_VERSION_STR.split('.')]
+OSX_VERSION_INFO = [int(part) for part in OSX_VERSION_STR.split('.')]
+OSX_VERSION_MAJOR_INT = OSX_VERSION_INFO[0]
+OSX_VERSION_MINOR_INT = OSX_VERSION_INFO[1]
+OSX_VERSION_MICRO_INT = 0
+
+if len(OSX_VERSION_INFO) >= 3:
+    OSX_VERSION_MICRO_INT = OSX_VERSION_INFO[2]
+
 
 sanitize_pattern = re.compile(r'^(\s*?\<string\>)(.*?)(\<\/string\>.*?)$')
 

--- a/usbinfo/darwin.py
+++ b/usbinfo/darwin.py
@@ -38,9 +38,13 @@ def _ioreg_usb_devices(nodename=None):
         """Run ioreg command on specific node name"""
         cmd = ['ioreg', '-a', '-l', '-r', '-n', nodename]
         output = subprocess.check_output(cmd)
+        plist_data = []
         if output:
-            return plistlib.readPlistFromString(output)
-        return []
+            try:
+                plist_data = plistlib.readPlistFromString(output)
+            except AttributeError as e:
+                plist_data = plistlib.loads(output)
+        return plist_data
 
     if nodename is None:
         xhci = _ioreg('AppleUSBXHCI')
@@ -97,7 +101,7 @@ def _extra_if_info(node):
     info = {}
 
     for child in node.get('IORegistryEntryChildren', []):
-        for class_name, handler in ioclass_handlers.iteritems():
+        for class_name, handler in ioclass_handlers.items():
             if child.get('IOObjectClass') == class_name:
                 info.update(handler(child))
         info.update(_extra_if_info(child))


### PR DESCRIPTION
Python 3.6.0's plistlib has removed readPlistFromString in favor of loads. There isn't a backwards compatible upgrade path, so feature detection was necessary instead.

This patch fixes Python 3.6.0 by trying plistlib.loads when AttributeError is thrown from attempting to call plistlib.readPlistFromString.

Additionally, dict.iteritems() is deprecated in favor of dict.items() in Python 3. This also works in Python 2.7.

Tested both Python 2.7 (standard install) and Python 3.6.0 (Anaconda) on macOS Sierra 10.12.4 (16E195).