### PR TITLE
Fix handling of pyudev output.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from setuptools import setup
 PKG_NAME = 'usbinfo'
 PKG_VERSION_MAJOR = 1
 PKG_VERSION_MINOR = 1
-PKG_VERSION_MICRO = 0
+PKG_VERSION_MICRO = 1
 PKG_VERSION = '{major}.{minor}.{micro}'.format(
     major=PKG_VERSION_MAJOR,
     minor=PKG_VERSION_MINOR,

--- a/usbinfo/linux.py
+++ b/usbinfo/linux.py
@@ -88,9 +88,6 @@ def _decode(unicode_str):
     Returns:
         A decoded string.
     """
-    def _escape(c):
-        return '\\x00\\x%02x' % ord(c)
-
     fixed_str = ''.join(
         [c if ord(c) < 128 else '\\x%02x' % ord(c) for c in unicode_str])
     return fixed_str.decode('string_escape')


### PR DESCRIPTION
pyudev can return strings with escaped and non-escaped unicode
characters. This change handles instances where such conditions occur.